### PR TITLE
Bump telethon version, add group spam guard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  celeritas:
+    image: celeritas_dev_compose
+    build:
+      context: .
+      dockerfile: docker/development/Dockerfile
+    container_name: celeritas
+    volumes:
+      - .:/app
+    stdin_open: true
+    tty: true
+    env_file: .env

--- a/mods/channel_travel.py
+++ b/mods/channel_travel.py
@@ -23,6 +23,10 @@ class ChannelTravel():
             update.message.reply_text("Nie masz uprawnień do korzystania z tej komendy.")
             return
 
+        if update.message.chat.type != "private":
+            update.message.reply_text("Zapytaj mnie o kanały na PW: @DraconisCeleritasBot")
+            return
+
         keyboard = []
         for c in self.channels:
             channel_name = c["name"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-dotenv==0.9.1
 python-telegram-bot==12.2
-Telethon==1.10.9
+telethon==1.15.0


### PR DESCRIPTION
- bumps telethon version to 1.15.0
- adds a spam guard that direct users to invoke configuration panel on PM
- adds a docker-compose file